### PR TITLE
Disabled timeout on downloading

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,9 @@ const app = express();
 const PORT = 3004;
 
 app.get("/:id", (req, res) => {
+  // Disable request time out because cook.sh can take a long time
+  req.setTimeout(0);
+  
   const id = Number(req.params.id);
   if (isNaN(id) || !Cooker.recordExists(id)) {
     res.status(404);


### PR DESCRIPTION
The cook.sh script can take a long time to return any data when processing large files. It is not enough to disable time out on the download client side because nodeJS has its own internal timeouts too.